### PR TITLE
Moving dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.2.0",
     "grunt": "~0.4.1",
-    "grunt-contrib-coffee": "~0.7.0",
+    "grunt-contrib-coffee": "~0.7.0"
+  },
+  "dependencies": {
     "underscore": "~1.5.2",
     "underscore.string": "~2.3.3"
   },


### PR DESCRIPTION
As _underscore_ is needed by the plugin, when it's located in **devDependencies**, it will be not installed with the plugin, generating **>> Error: Cannot find module 'underscore'** error.
